### PR TITLE
Add Compatibility API to WPGatsby

### DIFF
--- a/packages/wp-gatsby/src/ActionMonitor/ActionMonitor.php
+++ b/packages/wp-gatsby/src/ActionMonitor/ActionMonitor.php
@@ -838,5 +838,3 @@ class ActionMonitor
         register_post_type("action_monitor", $args);
     }
 }
-
-?>

--- a/packages/wp-gatsby/src/Admin/Preview.php
+++ b/packages/wp-gatsby/src/Admin/Preview.php
@@ -128,5 +128,3 @@ class Preview {
       );
     }
 }
-
-?>

--- a/packages/wp-gatsby/src/GraphQL/Auth.php
+++ b/packages/wp-gatsby/src/GraphQL/Auth.php
@@ -30,5 +30,3 @@ class Auth {
     return $jwt;
   }
 }
-
-?>

--- a/packages/wp-gatsby/src/GraphQL/ParseAuthToken.php
+++ b/packages/wp-gatsby/src/GraphQL/ParseAuthToken.php
@@ -25,5 +25,3 @@ class ParseAuthToken {
     }
 
 }
-
-?>

--- a/packages/wp-gatsby/src/Schema/PostTypes.php
+++ b/packages/wp-gatsby/src/Schema/PostTypes.php
@@ -29,8 +29,7 @@ class PostTypes
     {
         add_action(
             'graphql_register_types', function () {
-                $this->registerObjectTypes();
-                $this->registerFields();
+                $this->register();
             }
         );
     }
@@ -38,8 +37,9 @@ class PostTypes
     /**
      * Registers fields for the postTypes root field
      */
-    function registerFields() {
-        \register_graphql_field(
+    function register() {
+
+        register_graphql_field(
             'RootQuery', 'postTypes', [
             'type' => ['list_of' => 'PostTypeInfo'],
             'description' => __('Returns a list of available post types', 'wp-gatsby'),
@@ -103,13 +103,8 @@ class PostTypes
             },
             ]
         );
-    }
 
-    /**
-     * Registers GraphQL object types for postTypes root field
-     */
-    function registerObjectTypes() {
-        \register_graphql_object_type(
+        register_graphql_object_type(
             'PostTypeInfoGraphQLFieldNames',
             [
                 'description' => 'The GraphQL field names for a registered post type',
@@ -146,4 +141,3 @@ class PostTypes
         );
     }
 }
-?>

--- a/packages/wp-gatsby/src/Schema/Schema.php
+++ b/packages/wp-gatsby/src/Schema/Schema.php
@@ -16,4 +16,3 @@ class Schema
         new SiteMeta();
     }
 }
-?>

--- a/packages/wp-gatsby/src/Schema/SiteMeta.php
+++ b/packages/wp-gatsby/src/Schema/SiteMeta.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace WPGatsby\Schema;
-
 /**
  * Adds info about the current site
  */
@@ -14,7 +13,7 @@ class SiteMeta
     {
         add_action(
             'graphql_register_types', function () {
-                $this->registerFields();
+                $this->register();
             }
         );
     }
@@ -22,8 +21,142 @@ class SiteMeta
     /**
      * Registers site meta fields...
      */
-    function registerFields() {
-        \register_graphql_field(
+    function register() {
+
+	    register_graphql_object_type( 'WPGatsbyCompatiblity', [
+		    'description' => __( 'Check compatibility with a given version of gatsby-source-wordpress and the WordPress source site.' ),
+		    'fields' => [
+			    'isCompatible' => [
+				    'type' => 'Boolean',
+				    'description' => __( 'Whether the provided version of the gatsby-source-wordpress plugin is compatible with the WordPress server', 'wp-gatsby' ),
+			    ],
+			    'messages' => [
+				    'type' => [ 'list_of' => 'String' ],
+				    'description' => __( 'If the provided version of gatsby-source-wordpress is incompatible, theses messages will provide further information.', 'wp-gatsby'),
+			    ],
+		    ]
+	    ] );
+
+	    register_graphql_field( 'RootQuery', 'wpGatsbyCompatibility', [
+		    'description' => __( 'Information about the compatibility of the WordPress server with a provided version of gatsby-source-wordpress.', 'wp-gatsby' ),
+		    'type' => 'WPGatsbyCompatiblity',
+		    'args' => [
+			    'version' => [
+				    'type' => [ 'non_null' => 'String' ],
+				    'description' => __( 'The version of the gatsby-source-wordPress plugin to check compatibility with', 'wp-gatsby' ),
+			    ],
+		    ],
+		    'resolve' => function( $root, $args, $context, $info ) {
+
+			    $is_compatible = true;
+			    $messages = [];
+			    $version = isset( $args['version'] ) ? $args['version'] : null;
+
+			    if ( empty( $version ) ) {
+					$is_compatible = false;
+					$messages[] = __( 'No version was provided for the compatibility check. Please provide a valid version of the gatsby-source-wordpress plugin.', 'wp-gatsby' );
+			    }
+
+			    // @todo: Update path when this moves away from Tyler's fork
+			    $remote_compatibility = wp_remote_get( 'https://raw.githubusercontent.com/TylerBarnes/gatsby/feat/source-wordpress-v4/packages/wp-gatsby/compatibility.json' );
+
+			    /**
+			     * If the remote file cannot be fetched and returned properly, fallback to the local file in the installed version of WPGatsby
+			     */
+			    if ( is_wp_error( $remote_compatibility ) || 200 !== $remote_compatibility['response']['code'] || empty( $remote_compatibility['body'] ) )  {
+				    $compatibility_file = file_get_contents( WPGATSBY_PLUGIN_DIR . 'compatibility.json' );
+				    $compatibility = ! empty( $compatibility_file ) ? json_decode( $compatibility_file, true ) : null;
+			    } else {
+				    $compatibility = json_decode( $remote_compatibility['body'], true );
+			    }
+
+			    /**
+			     * If compatibility info cannot be determined
+			     */
+			    if ( empty( $compatibility ) || ! isset( $compatibility[ $version ] ) ) {
+
+					$is_compatible = false;
+					$messages[] = sprintf( __( 'The compatibility for version %s could not be determined', 'wp-gatsby' ), $version );
+
+			    } else {
+
+				    /**
+				     * Get the versions of WPGraphQL and WPGatsby
+				     */
+				    $installed_wpgraphql_version = defined( 'WPGRAPHQL_VERSION' ) ? WPGRAPHQL_VERSION : null;
+				    $installed__wpgatsby_version = defined( 'WPGATSBY_VERSION' ) ? WPGATSBY_VERSION : null;
+			    	$version_compat = $compatibility[ $version ];
+
+			    	// If wp-graphql isn't specified for a specific version
+			    	if ( ! isset( $version_compat['wp-graphql'] ) ) {
+					    $is_compatible = false;
+						$messages[] = sprintf(__( 'The version of WPGraphQL compatible with gatsby-source-wordpress v%s could not be determined', 'wp-gatsby' ), $version );
+				    }
+
+				    // If wp-gatsby isn't specified for as specific version
+				    if ( ! isset( $version_compat['wp-gatsby'] ) ) {
+					    $is_compatible = false;
+					    $messages[] = sprintf(__( 'The version of WPGatsby compatible with gatsby-source-wordpress v%s could not be determined', 'wp-gatsby' ), $version );
+				    }
+
+				    // If active WPGraphQL is lower than compatible min
+				    if ( ! isset( $version_compat['wp-graphql']['min'] ) ) {
+					    $is_compatible = false;
+					    $messages[] = sprintf(__( 'The minimum required version of WPGraphQL compatible with gatsby-source-wordpress v%s could not be determined', 'wp-gatsby' ), $version );
+				    } else {
+					    if ( ! version_compare( $installed_wpgraphql_version, $version_compat['wp-graphql']['min'], '>=' ) ) {
+						    $is_compatible = false;
+						    $messages[] = sprintf(__( 'The installed version of WPGraphQL (v%1$s) is lower than the required minimum version (v%2$s)', 'wp-gatsby' ), $installed_wpgraphql_version, $version_compat['wp-graphql']['min'] );
+					    }
+				    }
+
+				    // If active WPGraphQL is higher than compatible max
+				    if ( ! isset( $version_compat['wp-gatsby']['max'] ) ) {
+					    $is_compatible = false;
+					    $messages[] = sprintf(__( 'The max required version of WPGraphQL compatible with gatsby-source-wordpress v%s could not be determined', 'wp-gatsby' ), $version );
+				    } else {
+					    if ( ! version_compare( $installed_wpgraphql_version, $version_compat['wp-graphql']['max'], '<=' ) ) {
+						    $is_compatible = false;
+						    $messages[] = sprintf(__( 'The installed version of WPGraphQL (v%1$s) is higher than the max version (v%2$s) compatible with gatsby-source-wordpress %3$s', 'wp-gatsby' ), $installed_wpgraphql_version, $version_compat['wp-graphql']['max'], $version );
+					    }
+				    }
+
+				    // If active WPGatsby is lower than compatible min
+				    if ( ! isset( $version_compat['wp-gatsby']['min'] ) ) {
+					    $is_compatible = false;
+					    $messages[] = sprintf(__( 'The minimum required version of WPGatsby compatible with gatsby-source-wordpress v%s could not be determined', 'wp-gatsby' ), $version );
+				    } else {
+					    if ( ! version_compare( $installed__wpgatsby_version, $version_compat['wp-gatsby']['min'], '>=' ) ) {
+						    $is_compatible = false;
+						    $messages[] = sprintf(__( 'The installed version of WPGatsby (v%1$s) is lower than the required minimum version (v%2$s)', 'wp-gatsby' ), $installed__wpgatsby_version, $version_compat['wp-graphql']['min'] );
+					    }
+				    }
+
+				    // If active WPGatsby is higher than compatible max
+				    if ( ! isset( $version_compat['wp-gatsby']['max'] ) ) {
+					    $is_compatible = false;
+					    $messages[] = sprintf(__( 'The max required version of WPGatsby compatible with gatsby-source-wordpress v%s could not be determined', 'wp-gatsby' ), $version );
+				    } else {
+					    if ( ! version_compare( $installed__wpgatsby_version, $version_compat['wp-gatsby']['max'], '<=' ) ) {
+						    $is_compatible = false;
+						    $messages[] = sprintf(__( 'The installed version of WPGatsby (v%1$s) is higher than the max version (v%2$s) compatible with gatsby-source-wordpress %3$s', 'wp-gatsby' ), $installed__wpgatsby_version, $version_compat['wp-graphql']['max'], $version );
+					    }
+				    }
+
+			    }
+
+			    /**
+			     * Return the payload
+			     */
+			    return [
+			    	'isCompatible' => $is_compatible,
+				    'messages' => false === $is_compatible ? $messages : null,
+			    ];
+
+		    }
+	    ] );
+
+        register_graphql_field(
             'RootQuery', 'isWpGatsby', [
             'type' => 'Boolean',
             'description' => __('Confirms this is a WP Gatsby site', 'wp-gatsby'),
@@ -33,7 +166,7 @@ class SiteMeta
             ]
         );
 
-        \register_graphql_field(
+        register_graphql_field(
             'RootQuery', 'schemaMd5', [
             'type' => 'String',
             'description' => __('Returns an MD5 hash of the schema, useful in determining if the schema has changed.', 'wp-gatsby'),
@@ -86,4 +219,3 @@ class SiteMeta
         );
     }
 }
-?>

--- a/packages/wp-gatsby/wp-gatsby.php
+++ b/packages/wp-gatsby/wp-gatsby.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP Gatsby
  * Description: Optimize your WordPress site to be a source for Gatsby site(s).
- * Version: 0.1.11
+ * Version: 0.1.12
  * Author: GatsbyJS, Jason Bahl, Tyler Barnes
  * Author URI: https://gatsbyjs.org
  * Text Domain: wp-gatsby
@@ -37,6 +37,7 @@ final class WPGatsby
      * Returns instance of the main WPGatsby class
      *
      * @return WPGatsby
+     * @throws Exception
      */
     public static function instance()
     {
@@ -46,7 +47,7 @@ final class WPGatsby
 
             $minimum_php_version_met = self::$instance->min_php_version_check();
 
-            if ( WP_GATSBY_AUTOLOAD && $minimum_php_version_met ) {
+            if ( WPGATSBY_AUTOLOAD && $minimum_php_version_met ) {
               self::$instance->includes();
               self::$instance->init();
             }
@@ -67,7 +68,7 @@ final class WPGatsby
     {
 
         // Cloning instances of the class is forbidden.
-        _doing_it_wrong(__FUNCTION__, esc_html__('The WP_GATSBY_ class should not be cloned.', 'wp-gatsby'), '0.0.1');
+        _doing_it_wrong(__FUNCTION__, esc_html__('The WPGATSBY_ class should not be cloned.', 'wp-gatsby'), '0.0.1');
 
     }
 
@@ -82,7 +83,7 @@ final class WPGatsby
     {
 
         // De-serializing instances of the class is forbidden.
-        _doing_it_wrong(__FUNCTION__, esc_html__('De-serializing instances of the WP_GATSBY class is not allowed', 'wp-gatsby'), '0.0.1');
+        _doing_it_wrong(__FUNCTION__, esc_html__('De-serializing instances of the WPGATSBY class is not allowed', 'wp-gatsby'), '0.0.1');
 
     }
 
@@ -96,37 +97,37 @@ final class WPGatsby
     private function setup_constants()
     {
         // Plugin version.
-        if (! defined('WP_GATSBY_VERSION') ) {
-            define('WP_GATSBY_VERSION', '0.0.1');
+        if (! defined('WPGATSBY_VERSION') ) {
+            define('WPGATSBY_VERSION', '0.1.12');
         }
 
         // Plugin Folder Path.
-        if (! defined('WP_GATSBY_PLUGIN_DIR') ) {
-            define('WP_GATSBY_PLUGIN_DIR', plugin_dir_path(__FILE__));
+        if (! defined('WPGATSBY_PLUGIN_DIR') ) {
+            define('WPGATSBY_PLUGIN_DIR', plugin_dir_path(__FILE__));
         }
 
         // Plugin Folder URL.
-        if (! defined('WP_GATSBY_PLUGIN_URL') ) {
-            define('WP_GATSBY_PLUGIN_URL', plugin_dir_url(__FILE__));
+        if (! defined('WPGATSBY_PLUGIN_URL') ) {
+            define('WPGATSBY_PLUGIN_URL', plugin_dir_url(__FILE__));
         }
 
         // Plugin Root File.
-        if (! defined('WP_GATSBY_PLUGIN_FILE') ) {
-            define('WP_GATSBY_PLUGIN_FILE', __FILE__);
+        if (! defined('WPGATSBY_PLUGIN_FILE') ) {
+            define('WPGATSBY_PLUGIN_FILE', __FILE__);
         }
 
         // Whether to autoload the files or not.
-        if (! defined('WP_GATSBY_AUTOLOAD') ) {
+        if (! defined('WPGATSBY_AUTOLOAD') ) {
           define(
-            'WP_GATSBY_AUTOLOAD',
+            'WPGATSBY_AUTOLOAD',
             // only autoload if WPGQL is active
             defined('WPGRAPHQL_AUTOLOAD') ? true : false
           );
         }
 
         // Whether to run the plugin in debug mode. Default is false.
-        if (! defined('WP_GATSBY_DEBUG') ) {
-            define('WP_GATSBY_DEBUG', false);
+        if (! defined('WPGATSBY_DEBUG') ) {
+            define('WPGATSBY_DEBUG', false);
         }
 
     }
@@ -162,7 +163,7 @@ final class WPGatsby
     {
 
         /**
-         * WP_GATSBY_AUTOLOAD can be set to "false" to prevent the autoloader from running.
+         * WPGATSBY_AUTOLOAD can be set to "false" to prevent the autoloader from running.
          * In most cases, this is not something that should be disabled, but some environments
          * may bootstrap their dependencies in a global autoloader that will autoload files
          * before we get to this point, and requiring the autoloader again can trigger fatal errors.
@@ -170,13 +171,13 @@ final class WPGatsby
          * The codeception tests are an example of an environment where adding the autoloader again causes issues
          * so this is set to false for tests.
          */
-        if (defined('WP_GATSBY_AUTOLOAD') && true === WP_GATSBY_AUTOLOAD ) {
+        if (defined('WPGATSBY_AUTOLOAD') && true === WPGATSBY_AUTOLOAD ) {
             // Autoload Required Classes.
-            include_once WP_GATSBY_PLUGIN_DIR . 'vendor/autoload.php';
+            include_once WPGATSBY_PLUGIN_DIR . 'vendor/autoload.php';
         }
 
         // Required non-autoloaded classes.
-        include_once WP_GATSBY_PLUGIN_DIR . 'access-functions.php';
+        include_once WPGATSBY_PLUGIN_DIR . 'access-functions.php';
 
     }
 


### PR DESCRIPTION
- This updates the Schema to expose a new `RootQuery.wpGatsbyCompatibility` entry to query compatibility with a given version of gatsby-source-wordpress
- When querying, a version is required input, and that version is checked first against a remote compatibility file, then falls back to checking a local file. If the installed version of WPGraphQL or WPGatsby is outside the min/max specified versions, it will be marked as `isCompatible: false` and message(s) will be returned with further information

Example:

```
{
  isWpGatsby
  wpGatsbyCompatibility(version: "0.0.27") {
    messages
    isCompatible
  }
}
```

![Screen Shot 2020-04-10 at 2 29 48 PM](https://user-images.githubusercontent.com/1260765/79021060-ccf13900-7b37-11ea-9026-5932acbee919.png)
